### PR TITLE
Fix the issue where the skeleton has a style that is not the same as the custom style for the calendar

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,7 @@ const GitHubCalendar: FunctionComponent<Props> = ({
   }
 
   if (loading || !data) {
-    return <Skeleton loading />;
+    return <Skeleton {...props} loading />;
   }
 
   const theme = props.color ? undefined : props.theme ?? DEFAULT_THEME;


### PR DESCRIPTION
Pass props to skeleton to fix the issue where the skeleton has a style that is not the same as the custom style for the calendar.

Example:

![](https://i.imgur.com/X2gG9WI.png)