### PR TITLE
docs(readme): update the typo of usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ npm install react-github-calendar
 ## Usage
 
 ```tsx
-import GitHubCalendar from 'react-github-calendar'
+import GitHubCalendar from 'react-github-calendar';
 
-;<GitHubCalendar username="grubersjoe" />
+<GitHubCalendar username="grubersjoe" />
 ```
 
 ## FAQ


### PR DESCRIPTION
I found that the semicolon (`;`) was mistakenly placed on the wrong line. Therefore, I moved it to the correct position in the import statement.