### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-node@v4.2.0
+      - uses: actions/setup-node@v4.3.0
         with:
           node-version: 20
 
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v4.2.2
+      - uses: actions/cache@v4.2.3
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.3.0](https://github.com/actions/setup-node/releases/tag/v4.3.0)** on 2025-03-17T02:44:28Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.3](https://github.com/actions/cache/releases/tag/v4.2.3)** on 2025-03-19T18:18:32Z
